### PR TITLE
fix: validate repo parameter is defiend

### DIFF
--- a/awesome
+++ b/awesome
@@ -284,6 +284,10 @@ fn_rm() {
 # fn_update takes a script name (like tldr, not a repo name tldr-sh-client) and run git pull
 fn_update() {
     repo=$1
+    if [[ -z $repo ]]; then
+        printf "${RED}%s${RESET}\n" "Package name is missing."
+        exit 1
+    fi
     if [[ $(ls "$bin_dir") =~ $repo ]]; then
         # find the directory from symlink
         symlink_dir="$(myrealpath "$bin_dir/$repo")"


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
After running `awesome update` the command failed.
I realized from the source it was because I needed to pass a package.
Following this, I added a check to validate package is passed.  

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the tests and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->